### PR TITLE
Adopt quave:unblock package

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -31,3 +31,4 @@ zodern:types
 
 rspack@1.2.0
 montiapm:agent@3.0.0-beta.19
+quave:unblock@1.0.0

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -64,6 +64,7 @@ quave:migrations@2.0.2
 quave:react-meteor-data@3.0.0-beta300.7
 quave:settings@1.1.0
 quave:synced-cron@2.4.0
+quave:unblock@1.0.0
 random@1.2.2
 rate-limit@1.2.0
 react-fast-refresh@0.3.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,11 @@ code.
    module format required by their tool.
 7. Do not add commented-out code, dead imports, credentials, tokens, personal
    data, or environment-specific secrets.
+8. `quave:unblock` automatically unblocks every application method and publication.
+   Keep it after authentication packages in `.meteor/packages`; do not add redundant
+   `this.unblock()` calls. Direct `Meteor.server.method_handlers` overrides bypass the
+   package and must unblock themselves. A handler that calls `this.setUserId()` must
+   not be registered through the package-patched `Meteor.methods`.
 
 ## Frontend
 

--- a/internal-docs/ai/meteor.md
+++ b/internal-docs/ai/meteor.md
@@ -185,6 +185,19 @@ const doc = await MyCollection.saveAsync({ name: 'foo' });
 Every method is `async`. The method is the **only** place a mutation happens: validate,
 then write with `*Async`.
 
+### Default DDP unblocking
+
+The server-only `quave:unblock` package wraps `Meteor.methods` and `Meteor.publish`, so
+every application handler calls `this.unblock()` before its own code runs. Keep the
+package after authentication packages in `.meteor/packages`, and do not repeat
+`this.unblock()` inside ordinary methods or publications.
+
+Unblocked handlers from one connection may overlap, so each handler must authorize its
+own work and must not depend on another handler finishing first. Direct assignments to
+`Meteor.server.method_handlers` bypass the package and must call `this.unblock()` first.
+Meteor forbids `this.setUserId()` after unblocking; connection-authentication handlers
+that call it must load before `quave:unblock` or bypass the patched registration.
+
 ```javascript
 // app/clicks/clicksMethods.js  (server source of truth)
 import { Meteor } from 'meteor/meteor';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "meteor --settings private/env/dev/settings.json",
     "quave-check": "npm run quave-lint && npm run quave-format",
-    "test": "exit 0",
+    "test": "node --test tests/*.test.mjs",
     "quave-lint": "oxlint -c .oxlintrc.jsonc --fix --quiet .",
     "quave-format": "oxfmt \"**/*.js\"",
     "quave-lint:check": "oxlint -c .oxlintrc.jsonc --quiet .",

--- a/tests/meteorUnblock.test.mjs
+++ b/tests/meteorUnblock.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('quave:unblock loads after authentication packages', async function () {
+  const packages = await readFile('.meteor/packages', 'utf8');
+  const accountsPackageIndex = packages.indexOf(
+    'quave:accounts-passwordless-react'
+  );
+  const unblockPackageIndex = packages.indexOf('quave:unblock@1.0.0');
+
+  assert.notEqual(accountsPackageIndex, -1, 'expected the authentication package');
+  assert.ok(
+    unblockPackageIndex > accountsPackageIndex,
+    'quave:unblock must load after authentication packages'
+  );
+});


### PR DESCRIPTION
## What changed

- installs `quave:unblock@1.0.0` after framework and authentication packages
- changes the placeholder test command into a real Node test that verifies package ordering
- updates `AGENTS.md` and the detailed Meteor AI guide with concurrency, direct-handler, and `this.setUserId()` rules

## Why

Every application generated from the template should unblock Meteor methods and publications by default instead of relying on each future handler to remember `this.unblock()`.

## Validation

- `meteor npm test` (1/1 passed)
- `meteor npm run quave-check-ci`
- `git diff --check`
